### PR TITLE
Adding conditional "outline:none" for :focus state

### DIFF
--- a/_sass/hamburgers/_base.scss
+++ b/_sass/hamburgers/_base.scss
@@ -27,6 +27,12 @@
     }
   }
 
+  @if $hamburger-block-focus {
+    &:focus{
+      outline: none;
+    }
+  }
+
   &.is-active {
     &:hover {
       @if $hamburger-hover-use-filter == true {

--- a/_sass/hamburgers/hamburgers.scss
+++ b/_sass/hamburgers/hamburgers.scss
@@ -27,6 +27,9 @@ $hamburger-hover-use-filter   : false !default;
 $hamburger-hover-filter       : opacity(50%) !default;
 $hamburger-active-hover-filter: $hamburger-hover-filter !default;
 
+// Conditional :focus-state outline-blocking
+$hamburger-block-focus : true !default;
+
 // Types (Remove or comment out what you don’t need)
 // ==================================================
 $hamburger-types: (

--- a/_sass/hamburgers/hamburgers.scss
+++ b/_sass/hamburgers/hamburgers.scss
@@ -28,7 +28,7 @@ $hamburger-hover-filter       : opacity(50%) !default;
 $hamburger-active-hover-filter: $hamburger-hover-filter !default;
 
 // Conditional :focus-state outline-blocking
-$hamburger-block-focus : true !default;
+$hamburger-block-focus : false !default;
 
 // Types (Remove or comment out what you don’t need)
 // ==================================================


### PR DESCRIPTION
Hello,
ive added a boolean $hamburger-block-focus to your hamburger.scss.
related to this variable, ive added a conditional :focus{outline:none;} in the _base.scss.
Should work in every browser, because youre using the gulp-autoprefix.

**Thank you for this nice package :)**