### PR TITLE
Add ability to change speed of animations/transitions.

### DIFF
--- a/_sass/hamburgers/_base.scss
+++ b/_sass/hamburgers/_base.scss
@@ -66,7 +66,7 @@
     border-radius: $hamburger-layer-border-radius;
     position: absolute;
     transition-property: transform;
-    transition-duration: 0.15s;
+    transition-duration: (0.15s * $hamburger-scale-speed);
     transition-timing-function: ease;
   }
 

--- a/_sass/hamburgers/hamburgers.scss
+++ b/_sass/hamburgers/hamburgers.scss
@@ -19,6 +19,7 @@ $hamburger-layer-border-radius : 4px !default;
 $hamburger-hover-opacity       : 0.7 !default;
 $hamburger-active-layer-color  : $hamburger-layer-color !default;
 $hamburger-active-hover-opacity: $hamburger-hover-opacity !default;
+$hamburger-scale-speed         : 1 !default;
 
 // To use CSS filters as the hover effect instead of opacity,
 // set $hamburger-hover-use-filter as true and

--- a/_sass/hamburgers/types/_3dx-r.scss
+++ b/_sass/hamburgers/types/_3dx-r.scss
@@ -8,12 +8,12 @@
     }
 
     .hamburger-inner {
-      transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1),
-                  background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+      transition: transform ($hamburger-scale-speed * 0.15s) cubic-bezier(0.645, 0.045, 0.355, 1),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
 
       &::before,
       &::after {
-        transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+        transition: transform ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
       }
     }
 

--- a/_sass/hamburgers/types/_3dx.scss
+++ b/_sass/hamburgers/types/_3dx.scss
@@ -8,12 +8,12 @@
     }
 
     .hamburger-inner {
-      transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1),
-                  background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+      transition: transform ($hamburger-scale-speed * 0.15s) cubic-bezier(0.645, 0.045, 0.355, 1),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
 
       &::before,
       &::after {
-        transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+        transition: transform ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
       }
     }
 

--- a/_sass/hamburgers/types/_3dxy-r.scss
+++ b/_sass/hamburgers/types/_3dxy-r.scss
@@ -8,12 +8,12 @@
     }
 
     .hamburger-inner {
-      transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1),
-                  background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+      transition: transform ($hamburger-scale-speed * 0.15s) cubic-bezier(0.645, 0.045, 0.355, 1),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
 
       &::before,
       &::after {
-        transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+        transition: transform ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
       }
     }
 

--- a/_sass/hamburgers/types/_3dxy.scss
+++ b/_sass/hamburgers/types/_3dxy.scss
@@ -8,12 +8,12 @@
     }
 
     .hamburger-inner {
-      transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1),
-                  background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+      transition: transform ($hamburger-scale-speed * 0.15s) cubic-bezier(0.645, 0.045, 0.355, 1),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
 
       &::before,
       &::after {
-        transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+        transition: transform ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
       }
     }
 

--- a/_sass/hamburgers/types/_3dy-r.scss
+++ b/_sass/hamburgers/types/_3dy-r.scss
@@ -8,12 +8,12 @@
     }
 
     .hamburger-inner {
-      transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1),
-                  background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+      transition: transform ($hamburger-scale-speed * 0.15s) cubic-bezier(0.645, 0.045, 0.355, 1),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
 
       &::before,
       &::after {
-        transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+        transition: transform ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
       }
     }
 

--- a/_sass/hamburgers/types/_3dy.scss
+++ b/_sass/hamburgers/types/_3dy.scss
@@ -8,12 +8,12 @@
     }
 
     .hamburger-inner {
-      transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1),
-                  background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+      transition: transform ($hamburger-scale-speed * 0.15s) cubic-bezier(0.645, 0.045, 0.355, 1),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
 
       &::before,
       &::after {
-        transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1);
+        transition: transform ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.645, 0.045, 0.355, 1);
       }
     }
 

--- a/_sass/hamburgers/types/_arrowalt-r.scss
+++ b/_sass/hamburgers/types/_arrowalt-r.scss
@@ -5,13 +5,13 @@
   .hamburger--arrowalt-r {
     .hamburger-inner {
       &::before {
-        transition: top 0.1s 0.1s ease,
-                    transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1);
+        transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) ease,
+                    transform ($hamburger-scale-speed * 0.1s) cubic-bezier(0.165, 0.84, 0.44, 1);
       }
 
       &::after {
-        transition: bottom 0.1s 0.1s ease,
-                    transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1);
+        transition: bottom ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) ease,
+                    transform ($hamburger-scale-speed * 0.1s) cubic-bezier(0.165, 0.84, 0.44, 1);
       }
     }
 
@@ -20,15 +20,15 @@
         &::before {
           top: 0;
           transform: translate3d($hamburger-layer-width * 0.2, $hamburger-layer-width * -0.25, 0) rotate(45deg) scale(0.7, 1);
-          transition: top 0.1s ease,
-                      transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22);
+          transition: top ($hamburger-scale-speed * 0.1s) ease,
+                      transform ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.895, 0.03, 0.685, 0.22);
         }
 
         &::after {
           bottom: 0;
           transform: translate3d($hamburger-layer-width * 0.2, $hamburger-layer-width * 0.25, 0) rotate(-45deg) scale(0.7, 1);
-          transition: bottom 0.1s ease,
-                      transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22);
+          transition: bottom ($hamburger-scale-speed * 0.1s) ease,
+                      transform ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.895, 0.03, 0.685, 0.22);
         }
       }
     }

--- a/_sass/hamburgers/types/_arrowalt.scss
+++ b/_sass/hamburgers/types/_arrowalt.scss
@@ -5,13 +5,13 @@
   .hamburger--arrowalt {
     .hamburger-inner {
       &::before {
-        transition: top 0.1s 0.1s ease,
-                    transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1);
+        transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) ease,
+                    transform ($hamburger-scale-speed * 0.1s) cubic-bezier(0.165, 0.84, 0.44, 1);
       }
 
       &::after {
-        transition: bottom 0.1s 0.1s ease,
-                    transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1);
+        transition: bottom ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) ease,
+                    transform ($hamburger-scale-speed * 0.1s) cubic-bezier(0.165, 0.84, 0.44, 1);
       }
     }
 
@@ -20,15 +20,15 @@
         &::before {
           top: 0;
           transform: translate3d($hamburger-layer-width * -0.2, $hamburger-layer-width * -0.25, 0) rotate(-45deg) scale(0.7, 1);
-          transition: top 0.1s ease,
-                      transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22);
+          transition: top ($hamburger-scale-speed * 0.1s) ease,
+                      transform ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.895, 0.03, 0.685, 0.22);
         }
 
         &::after {
           bottom: 0;
           transform: translate3d($hamburger-layer-width * -0.2, $hamburger-layer-width * 0.25, 0) rotate(45deg) scale(0.7, 1);
-          transition: bottom 0.1s ease,
-                      transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22);
+          transition: bottom ($hamburger-scale-speed * 0.1s) ease,
+                      transform ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.1s) cubic-bezier(0.895, 0.03, 0.685, 0.22);
         }
       }
     }

--- a/_sass/hamburgers/types/_collapse-r.scss
+++ b/_sass/hamburgers/types/_collapse-r.scss
@@ -6,40 +6,40 @@
     .hamburger-inner {
       top: auto;
       bottom: 0;
-      transition-duration: 0.13s;
-      transition-delay: 0.13s;
+      transition-duration: ($hamburger-scale-speed * 0.13s);
+      transition-delay: ($hamburger-scale-speed * 0.13s);
       transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
 
       &::after {
         top: ($hamburger-layer-spacing * 2 + $hamburger-layer-height * 2) * -1;
-        transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    opacity 0.1s linear;
+        transition: top ($hamburger-scale-speed * 0.2s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    opacity ($hamburger-scale-speed * 0.1s) linear;
       }
 
       &::before {
-        transition: top 0.12s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: top ($hamburger-scale-speed * 0.12s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    transform ($hamburger-scale-speed * 0.13s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
     &.is-active {
       .hamburger-inner {
         transform: translate3d(0, ($hamburger-layer-spacing + $hamburger-layer-height) * -1, 0) rotate(45deg);
-        transition-delay: 0.22s;
+        transition-delay: ($hamburger-scale-speed * 0.22s);
         transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
 
         &::after {
           top: 0;
           opacity: 0;
-          transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      opacity 0.1s 0.22s linear;
+          transition: top ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      opacity ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.22s) linear;
         }
 
         &::before {
           top: 0;
           transform: rotate(90deg);
-          transition: top 0.1s 0.16s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      transform 0.13s 0.25s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.16s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      transform ($hamburger-scale-speed * 0.13s) ($hamburger-scale-speed * 0.25s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_collapse.scss
+++ b/_sass/hamburgers/types/_collapse.scss
@@ -6,40 +6,40 @@
     .hamburger-inner {
       top: auto;
       bottom: 0;
-      transition-duration: 0.13s;
-      transition-delay: 0.13s;
+      transition-duration: ($hamburger-scale-speed * 0.13s);
+      transition-delay: ($hamburger-scale-speed * 0.13s);
       transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
 
       &::after {
         top: ($hamburger-layer-spacing * 2 + $hamburger-layer-height * 2) * -1;
-        transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    opacity 0.1s linear;
+        transition: top ($hamburger-scale-speed * 0.2s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    opacity ($hamburger-scale-speed * 0.1s) linear;
       }
 
       &::before {
-        transition: top 0.12s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: top ($hamburger-scale-speed * 0.12s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    transform ($hamburger-scale-speed * 0.13s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
     &.is-active {
       .hamburger-inner {
         transform: translate3d(0, ($hamburger-layer-spacing + $hamburger-layer-height) * -1, 0) rotate(-45deg);
-        transition-delay: 0.22s;
+        transition-delay: ($hamburger-scale-speed * 0.22s);
         transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
 
         &::after {
           top: 0;
           opacity: 0;
-          transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      opacity 0.1s 0.22s linear;
+          transition: top ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      opacity ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.22s) linear;
         }
 
         &::before {
           top: 0;
           transform: rotate(-90deg);
-          transition: top 0.1s 0.16s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      transform 0.13s 0.25s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.16s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      transform ($hamburger-scale-speed * 0.13s) ($hamburger-scale-speed * 0.25s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_elastic-r.scss
+++ b/_sass/hamburgers/types/_elastic-r.scss
@@ -5,17 +5,17 @@
   .hamburger--elastic-r {
     .hamburger-inner {
       top: $hamburger-layer-height / 2;
-      transition-duration: 0.275s;
+      transition-duration: ($hamburger-scale-speed * 0.275s);
       transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 
       &::before {
         top: $hamburger-layer-height + $hamburger-layer-spacing;
-        transition: opacity 0.125s 0.275s ease;
+        transition: opacity ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.275s) ease;
       }
 
       &::after {
         top: ($hamburger-layer-height * 2) + ($hamburger-layer-spacing * 2);
-        transition: transform 0.275s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+        transition: transform ($hamburger-scale-speed * 0.275s) cubic-bezier(0.68, -0.55, 0.265, 1.55);
       }
     }
 
@@ -24,16 +24,16 @@
         $y-offset: $hamburger-layer-spacing + $hamburger-layer-height;
 
         transform: translate3d(0, $y-offset, 0) rotate(-135deg);
-        transition-delay: 0.075s;
+        transition-delay: ($hamburger-scale-speed * 0.075s);
 
         &::before {
-          transition-delay: 0s;
+          transition-delay: ($hamburger-scale-speed * 0s);
           opacity: 0;
         }
 
         &::after {
           transform: translate3d(0, $y-offset * -2, 0) rotate(270deg);
-          transition-delay: 0.075s;
+          transition-delay: ($hamburger-scale-speed * 0.075s);
         }
       }
     }

--- a/_sass/hamburgers/types/_elastic.scss
+++ b/_sass/hamburgers/types/_elastic.scss
@@ -5,17 +5,17 @@
   .hamburger--elastic {
     .hamburger-inner {
       top: $hamburger-layer-height / 2;
-      transition-duration: 0.275s;
+      transition-duration: ($hamburger-scale-speed * 0.275s);
       transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 
       &::before {
         top: $hamburger-layer-height + $hamburger-layer-spacing;
-        transition: opacity 0.125s 0.275s ease;
+        transition: opacity ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.275s) ease;
       }
 
       &::after {
         top: ($hamburger-layer-height * 2) + ($hamburger-layer-spacing * 2);
-        transition: transform 0.275s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+        transition: transform ($hamburger-scale-speed * 0.275s) cubic-bezier(0.68, -0.55, 0.265, 1.55);
       }
     }
 
@@ -24,16 +24,16 @@
         $y-offset: $hamburger-layer-spacing + $hamburger-layer-height;
 
         transform: translate3d(0, $y-offset, 0) rotate(135deg);
-        transition-delay: 0.075s;
+        transition-delay: ($hamburger-scale-speed * 0.075s);
 
         &::before {
-          transition-delay: 0s;
+          transition-delay: ($hamburger-scale-speed * 0s);
           opacity: 0;
         }
 
         &::after {
           transform: translate3d(0, $y-offset * -2, 0) rotate(-270deg);
-          transition-delay: 0.075s;
+          transition-delay: ($hamburger-scale-speed * 0.075s);
         }
       }
     }

--- a/_sass/hamburgers/types/_emphatic-r.scss
+++ b/_sass/hamburgers/types/_emphatic-r.scss
@@ -6,27 +6,27 @@
     overflow: hidden;
 
     .hamburger-inner {
-      transition: background-color 0.125s 0.175s ease-in;
+      transition: background-color ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) ease-in;
 
       &::before {
         left: 0;
-        transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335),
-                    top 0.05s 0.125s linear,
-                    left 0.125s 0.175s ease-in;
+        transition: transform ($hamburger-scale-speed * 0.125s) cubic-bezier(0.6, 0.04, 0.98, 0.335),
+                    top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                    left ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) ease-in;
       }
 
       &::after {
         top: ($hamburger-layer-height) + ($hamburger-layer-spacing);
         right: 0;
-        transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335),
-                    top 0.05s 0.125s linear,
-                    right 0.125s 0.175s ease-in;
+        transition: transform ($hamburger-scale-speed * 0.125s) cubic-bezier(0.6, 0.04, 0.98, 0.335),
+                    top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                    right ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) ease-in;
       }
     }
 
     &.is-active {
       .hamburger-inner {
-        transition-delay: 0s;
+        transition-delay: ($hamburger-scale-speed * 0s);
         transition-timing-function: ease-out;
         background-color: transparent !important;
 
@@ -34,18 +34,18 @@
           left: $hamburger-layer-width * -2;
           top: $hamburger-layer-width * 2;
           transform: translate3d($hamburger-layer-width * 2, $hamburger-layer-width * -2, 0) rotate(-45deg);
-          transition: left 0.125s ease-out,
-                      top 0.05s 0.125s linear,
-                      transform 0.125s 0.175s cubic-bezier(0.075, 0.82, 0.165, 1);
+          transition: left ($hamburger-scale-speed * 0.125s) ease-out,
+                      top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                      transform ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) cubic-bezier(0.075, 0.82, 0.165, 1);
         }
 
         &::after {
           right: $hamburger-layer-width * -2;
           top: $hamburger-layer-width * 2;
           transform: translate3d($hamburger-layer-width * -2, $hamburger-layer-width * -2, 0) rotate(45deg);
-          transition: right 0.125s ease-out,
-                      top 0.05s 0.125s linear,
-                      transform 0.125s 0.175s cubic-bezier(0.075, 0.82, 0.165, 1);
+          transition: right ($hamburger-scale-speed * 0.125s) ease-out,
+                      top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                      transform ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) cubic-bezier(0.075, 0.82, 0.165, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_emphatic.scss
+++ b/_sass/hamburgers/types/_emphatic.scss
@@ -6,27 +6,27 @@
     overflow: hidden;
 
     .hamburger-inner {
-      transition: background-color 0.125s 0.175s ease-in;
+      transition: background-color ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) ease-in;
 
       &::before {
         left: 0;
-        transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335),
-                    top 0.05s 0.125s linear,
-                    left 0.125s 0.175s ease-in;
+        transition: transform ($hamburger-scale-speed * 0.125s) cubic-bezier(0.6, 0.04, 0.98, 0.335),
+                    top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                    left ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) ease-in;
       }
 
       &::after {
         top: ($hamburger-layer-height) + ($hamburger-layer-spacing);
         right: 0;
-        transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335),
-                    top 0.05s 0.125s linear,
-                    right 0.125s 0.175s ease-in;
+        transition: transform ($hamburger-scale-speed * 0.125s) cubic-bezier(0.6, 0.04, 0.98, 0.335),
+                    top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                    right ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) ease-in;
       }
     }
 
     &.is-active {
       .hamburger-inner {
-        transition-delay: 0s;
+        transition-delay: ($hamburger-scale-speed * 0s);
         transition-timing-function: ease-out;
         background-color: transparent !important;
 
@@ -34,18 +34,18 @@
           left: $hamburger-layer-width * -2;
           top: $hamburger-layer-width * -2;
           transform: translate3d($hamburger-layer-width * 2, $hamburger-layer-width * 2, 0) rotate(45deg);
-          transition: left 0.125s ease-out,
-                      top 0.05s 0.125s linear,
-                      transform 0.125s 0.175s cubic-bezier(0.075, 0.82, 0.165, 1);
+          transition: left ($hamburger-scale-speed * 0.125s) ease-out,
+                      top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                      transform ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) cubic-bezier(0.075, 0.82, 0.165, 1);
         }
 
         &::after {
           right: $hamburger-layer-width * -2;
           top: $hamburger-layer-width * -2;
           transform: translate3d($hamburger-layer-width * -2, $hamburger-layer-width * 2, 0) rotate(-45deg);
-          transition: right 0.125s ease-out,
-                      top 0.05s 0.125s linear,
-                      transform 0.125s 0.175s cubic-bezier(0.075, 0.82, 0.165, 1);
+          transition: right ($hamburger-scale-speed * 0.125s) ease-out,
+                      top ($hamburger-scale-speed * 0.05s) ($hamburger-scale-speed * 0.125s) linear,
+                      transform ($hamburger-scale-speed * 0.125s) ($hamburger-scale-speed * 0.175s) cubic-bezier(0.075, 0.82, 0.165, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_minus.scss
+++ b/_sass/hamburgers/types/_minus.scss
@@ -6,9 +6,9 @@
     .hamburger-inner {
       &::before,
       &::after {
-        transition: bottom 0.08s 0s ease-out,
-                    top 0.08s 0s ease-out,
-                    opacity 0s linear;
+        transition: bottom ($hamburger-scale-speed * 0.08s) ($hamburger-scale-speed * 0s) ease-out,
+                    top ($hamburger-scale-speed * 0.08s) ($hamburger-scale-speed * 0s) ease-out,
+                    opacity ($hamburger-scale-speed * 0s) linear;
       }
     }
 
@@ -17,9 +17,9 @@
         &::before,
         &::after {
           opacity: 0;
-          transition: bottom 0.08s ease-out,
-                      top 0.08s ease-out,
-                      opacity 0s 0.08s linear;
+          transition: bottom ($hamburger-scale-speed * 0.08s) ease-out,
+                      top ($hamburger-scale-speed * 0.08s) ease-out,
+                      opacity ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.08s) linear;
         }
         &::before {
           top: 0;

--- a/_sass/hamburgers/types/_slider-r.scss
+++ b/_sass/hamburgers/types/_slider-r.scss
@@ -10,7 +10,7 @@
         top: $hamburger-layer-height + $hamburger-layer-spacing;
         transition-property: transform, opacity;
         transition-timing-function: ease;
-        transition-duration: 0.15s;
+        transition-duration: ($hamburger-scale-speed * 0.15s);
       }
 
       &::after {

--- a/_sass/hamburgers/types/_slider.scss
+++ b/_sass/hamburgers/types/_slider.scss
@@ -10,7 +10,7 @@
         top: $hamburger-layer-height + $hamburger-layer-spacing;
         transition-property: transform, opacity;
         transition-timing-function: ease;
-        transition-duration: 0.15s;
+        transition-duration: ($hamburger-scale-speed * 0.15s);
       }
 
       &::after {

--- a/_sass/hamburgers/types/_spin-r.scss
+++ b/_sass/hamburgers/types/_spin-r.scss
@@ -4,38 +4,38 @@
    */
   .hamburger--spin-r {
     .hamburger-inner {
-      transition-duration: 0.22s;
+      transition-duration: ($hamburger-scale-speed * 0.22s);
       transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
 
       &::before {
-        transition: top 0.1s 0.25s ease-in,
-                    opacity 0.1s ease-in;
+        transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.25s) ease-in,
+                    opacity ($hamburger-scale-speed * 0.1s) ease-in;
       }
 
       &::after {
-        transition: bottom 0.1s 0.25s ease-in,
-                    transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: bottom ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.25s) ease-in,
+                    transform ($hamburger-scale-speed * 0.22s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
     &.is-active {
       .hamburger-inner {
         transform: rotate(-225deg);
-        transition-delay: 0.12s;
+        transition-delay: ($hamburger-scale-speed * 0.12s);
         transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
 
         &::before {
           top: 0;
           opacity: 0;
-          transition: top 0.1s ease-out,
-                      opacity 0.1s 0.12s ease-out;
+          transition: top ($hamburger-scale-speed * 0.1s) ease-out,
+                      opacity ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.12s) ease-out;
         }
 
         &::after {
           bottom: 0;
           transform: rotate(90deg);
-          transition: bottom 0.1s ease-out,
-                      transform 0.22s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: bottom ($hamburger-scale-speed * 0.1s) ease-out,
+                      transform ($hamburger-scale-speed * 0.22s) ($hamburger-scale-speed * 0.12s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_spin.scss
+++ b/_sass/hamburgers/types/_spin.scss
@@ -4,38 +4,38 @@
    */
   .hamburger--spin {
     .hamburger-inner {
-      transition-duration: 0.22s;
+      transition-duration: ($hamburger-scale-speed * 0.22s);
       transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
 
       &::before {
-        transition: top 0.1s 0.25s ease-in,
-                    opacity 0.1s ease-in;
+        transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.25s) ease-in,
+                    opacity ($hamburger-scale-speed * 0.1s) ease-in;
       }
 
       &::after {
-        transition: bottom 0.1s 0.25s ease-in,
-                    transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: bottom ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.25s) ease-in,
+                    transform ($hamburger-scale-speed * 0.22s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
     &.is-active {
       .hamburger-inner {
         transform: rotate(225deg);
-        transition-delay: 0.12s;
+        transition-delay: ($hamburger-scale-speed * 0.12s);
         transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
 
         &::before {
           top: 0;
           opacity: 0;
-          transition: top 0.1s ease-out,
-                      opacity 0.1s 0.12s ease-out;
+          transition: top ($hamburger-scale-speed * 0.1s) ease-out,
+                      opacity ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.12s) ease-out;
         }
 
         &::after {
           bottom: 0;
           transform: rotate(-90deg);
-          transition: bottom 0.1s ease-out,
-                      transform 0.22s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: bottom ($hamburger-scale-speed * 0.1s) ease-out,
+                      transform ($hamburger-scale-speed * 0.22s) ($hamburger-scale-speed * 0.12s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_spring-r.scss
+++ b/_sass/hamburgers/types/_spring-r.scss
@@ -6,40 +6,40 @@
     .hamburger-inner {
       top: auto;
       bottom: 0;
-      transition-duration: 0.13s;
-      transition-delay: 0s;
+      transition-duration: ($hamburger-scale-speed * 0.13s);
+      transition-delay: ($hamburger-scale-speed * 0s);
       transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
 
       &::after {
         top: ($hamburger-layer-spacing * 2 + $hamburger-layer-height * 2) * -1;
-        transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    opacity 0s linear;
+        transition: top ($hamburger-scale-speed * 0.2s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    opacity ($hamburger-scale-speed * 0s) linear;
       }
 
       &::before {
-        transition: top 0.1s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    transform ($hamburger-scale-speed * 0.13s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
     &.is-active {
       .hamburger-inner {
         transform: translate3d(0, ($hamburger-layer-spacing + $hamburger-layer-height) * -1, 0) rotate(-45deg);
-        transition-delay: 0.22s;
+        transition-delay: ($hamburger-scale-speed * 0.22s);
         transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
 
         &::after {
           top: 0;
           opacity: 0;
-          transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      opacity 0s 0.22s linear;
+          transition: top ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      opacity ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.22s) linear;
         }
 
         &::before {
           top: 0;
           transform: rotate(90deg);
-          transition: top 0.1s 0.15s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      transform 0.13s 0.22s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      transform ($hamburger-scale-speed * 0.13s) ($hamburger-scale-speed * 0.22s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_spring.scss
+++ b/_sass/hamburgers/types/_spring.scss
@@ -5,37 +5,37 @@
   .hamburger--spring {
     .hamburger-inner {
       top: $hamburger-layer-height / 2;
-      transition: background-color 0s 0.13s linear;
+      transition: background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.13s) linear;
 
       &::before {
         top: $hamburger-layer-height + $hamburger-layer-spacing;
-        transition: top 0.1s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    transform ($hamburger-scale-speed * 0.13s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
 
       &::after {
         top: ($hamburger-layer-height * 2) + ($hamburger-layer-spacing * 2);
-        transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1),
-                    transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: top ($hamburger-scale-speed * 0.2s) ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0.66667, 0.66667, 1),
+                    transform ($hamburger-scale-speed * 0.13s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
     &.is-active {
       .hamburger-inner {
-        transition-delay: 0.22s;
+        transition-delay: ($hamburger-scale-speed * 0.22s);
         background-color: transparent !important;
 
         &::before {
           top: 0;
-          transition: top 0.1s 0.15s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      transform 0.13s 0.22s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: top ($hamburger-scale-speed * 0.1s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      transform ($hamburger-scale-speed * 0.13s) ($hamburger-scale-speed * 0.22s) cubic-bezier(0.215, 0.61, 0.355, 1);
           transform: translate3d(0, $hamburger-layer-spacing + $hamburger-layer-height, 0) rotate(45deg);
         }
 
         &::after {
           top: 0;
-          transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333),
-                      transform 0.13s 0.22s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: top ($hamburger-scale-speed * 0.2s) cubic-bezier(0.33333, 0, 0.66667, 0.33333),
+                      transform ($hamburger-scale-speed * 0.13s) ($hamburger-scale-speed * 0.22s) cubic-bezier(0.215, 0.61, 0.355, 1);
           transform: translate3d(0, $hamburger-layer-spacing + $hamburger-layer-height, 0) rotate(-45deg);
         }
       }

--- a/_sass/hamburgers/types/_squeeze.scss
+++ b/_sass/hamburgers/types/_squeeze.scss
@@ -4,38 +4,38 @@
    */
   .hamburger--squeeze {
     .hamburger-inner {
-      transition-duration: 0.075s;
+      transition-duration: ($hamburger-scale-speed * 0.075s);
       transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
 
       &::before {
-        transition: top 0.075s 0.12s ease,
-                    opacity 0.075s ease;
+        transition: top ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.12s) ease,
+                    opacity ($hamburger-scale-speed * 0.075s) ease;
       }
 
       &::after {
-        transition: bottom 0.075s 0.12s ease,
-                    transform 0.075s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: bottom ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.12s) ease,
+                    transform ($hamburger-scale-speed * 0.075s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
     &.is-active {
       .hamburger-inner {
         transform: rotate(45deg);
-        transition-delay: 0.12s;
+        transition-delay: ($hamburger-scale-speed * 0.12s);
         transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
 
         &::before {
           top: 0;
           opacity: 0;
-          transition: top 0.075s ease,
-                      opacity 0.075s 0.12s ease;
+          transition: top ($hamburger-scale-speed * 0.075s) ease,
+                      opacity ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.12s) ease;
         }
 
         &::after {
           bottom: 0;
           transform: rotate(-90deg);
-          transition: bottom 0.075s ease,
-                      transform 0.075s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: bottom ($hamburger-scale-speed * 0.075s) ease,
+                      transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.12s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_stand-r.scss
+++ b/_sass/hamburgers/types/_stand-r.scss
@@ -4,17 +4,17 @@
    */
   .hamburger--stand-r {
     .hamburger-inner {
-      transition: transform 0.075s 0.15s cubic-bezier(0.55, 0.055, 0.675, 0.19),
-                  background-color 0s 0.075s linear;
+      transition: transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.55, 0.055, 0.675, 0.19),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.075s) linear;
 
       &::before {
-        transition: top 0.075s 0.075s ease-in,
-                    transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: top ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.075s) ease-in,
+                    transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
 
       &::after {
-        transition: bottom 0.075s 0.075s ease-in,
-                    transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: bottom ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.075s) ease-in,
+                    transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
@@ -23,21 +23,21 @@
         transform: rotate(-90deg);
         background-color: transparent !important;
 
-        transition: transform 0.075s 0s cubic-bezier(0.215, 0.61, 0.355, 1),
-                    background-color 0s 0.15s linear;
+        transition: transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0s) cubic-bezier(0.215, 0.61, 0.355, 1),
+                    background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.15s) linear;
 
         &::before {
           top: 0;
           transform: rotate(-45deg);
-          transition: top 0.075s 0.1s ease-out,
-                      transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: top ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.1s) ease-out,
+                      transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
 
         &::after {
           bottom: 0;
           transform: rotate(45deg);
-          transition: bottom 0.075s 0.1s ease-out,
-                      transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: bottom ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.1s) ease-out,
+                      transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_stand.scss
+++ b/_sass/hamburgers/types/_stand.scss
@@ -4,17 +4,17 @@
    */
   .hamburger--stand {
     .hamburger-inner {
-      transition: transform 0.075s 0.15s cubic-bezier(0.55, 0.055, 0.675, 0.19),
-                  background-color 0s 0.075s linear;
+      transition: transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.55, 0.055, 0.675, 0.19),
+                  background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.075s) linear;
 
       &::before {
-        transition: top 0.075s 0.075s ease-in,
-                    transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: top ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.075s) ease-in,
+                    transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
 
       &::after {
-        transition: bottom 0.075s 0.075s ease-in,
-                    transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition: bottom ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.075s) ease-in,
+                    transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0s) cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
@@ -23,21 +23,21 @@
         transform: rotate(90deg);
         background-color: transparent !important;
 
-        transition: transform 0.075s 0s cubic-bezier(0.215, 0.61, 0.355, 1),
-                    background-color 0s 0.15s linear;
+        transition: transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0s) cubic-bezier(0.215, 0.61, 0.355, 1),
+                    background-color ($hamburger-scale-speed * 0s) ($hamburger-scale-speed * 0.15s) linear;
 
         &::before {
           top: 0;
           transform: rotate(-45deg);
-          transition: top 0.075s 0.1s ease-out,
-                      transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: top ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.1s) ease-out,
+                      transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
 
         &::after {
           bottom: 0;
           transform: rotate(45deg);
-          transition: bottom 0.075s 0.1s ease-out,
-                      transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition: bottom ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.1s) ease-out,
+                      transform ($hamburger-scale-speed * 0.075s) ($hamburger-scale-speed * 0.15s) cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/_sass/hamburgers/types/_vortex-r.scss
+++ b/_sass/hamburgers/types/_vortex-r.scss
@@ -4,13 +4,13 @@
    */
   .hamburger--vortex-r {
     .hamburger-inner {
-      transition-duration: 0.2s;
+      transition-duration: ($hamburger-scale-speed * 0.2s);
       transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1);
 
       &::before,
       &::after {
-        transition-duration: 0s;
-        transition-delay: 0.1s;
+        transition-duration: ($hamburger-scale-speed * 0s);
+        transition-delay: ($hamburger-scale-speed * 0.1s);
         transition-timing-function: linear;
       }
 
@@ -30,7 +30,7 @@
 
         &::before,
         &::after {
-          transition-delay: 0s;
+          transition-delay: ($hamburger-scale-speed * 0s);
         }
 
         &::before {

--- a/_sass/hamburgers/types/_vortex.scss
+++ b/_sass/hamburgers/types/_vortex.scss
@@ -4,13 +4,13 @@
    */
   .hamburger--vortex {
     .hamburger-inner {
-      transition-duration: 0.2s;
+      transition-duration: ($hamburger-scale-speed * 0.2s);
       transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1);
 
       &::before,
       &::after {
-        transition-duration: 0s;
-        transition-delay: 0.1s;
+        transition-duration: ($hamburger-scale-speed * 0s);
+        transition-delay: ($hamburger-scale-speed * 0.1s);
         transition-timing-function: linear;
       }
 
@@ -30,7 +30,7 @@
 
         &::before,
         &::after {
-          transition-delay: 0s;
+          transition-delay: ($hamburger-scale-speed * 0s);
         }
 
         &::before {


### PR DESCRIPTION
Thanks for this amazingly useful and flexible library! With the wide selection, I felt just one minor thing was missing: **ability to adjust animation speed**.

This PR enables a little extra creative freedom with the ability to simply adjust the built-in animation speeds by a scale factor (with the default being 1x). All this does is multiply all of the existing values by a value that you can provide.


**Example 1x scale (default):** 
```
$hamburger-scale-speed: 1;
```
![scale speed 1x](https://user-images.githubusercontent.com/4269377/52512672-025c6880-2bbb-11e9-86e0-0fa8763988eb.gif)



**Example 10x scale:**
```
$hamburger-scale-speed: 10;
```

![scale speed 10x](https://user-images.githubusercontent.com/4269377/52512681-0e482a80-2bbb-11e9-8255-1b562d3e1892.gif)


This at least allows folks like me to very quickly and easily adjust the animation speeds without digging to deep into the weeds and manually editing every value and attempting to scale it evenly to ensure everything is coordinated.
