### PR TITLE
Moved variables to `_vars.scss` file

### DIFF
--- a/_sass/hamburgers/_vars.scss
+++ b/_sass/hamburgers/_vars.scss
@@ -1,0 +1,56 @@
+// Variables
+
+// ==================================================
+$hamburger-padding-x           : 15px !default;
+$hamburger-padding-y           : 15px !default;
+$hamburger-layer-width         : 40px !default;
+$hamburger-layer-height        : 4px !default;
+$hamburger-layer-spacing       : 6px !default;
+$hamburger-layer-color         : #000 !default;
+$hamburger-layer-border-radius : 4px !default;
+$hamburger-hover-opacity       : 0.7 !default;
+$hamburger-active-layer-color  : $hamburger-layer-color !default;
+$hamburger-active-hover-opacity: $hamburger-hover-opacity !default;
+
+// To use CSS filters as the hover effect instead of opacity,
+// set $hamburger-hover-use-filter as true and
+// change the value of $hamburger-hover-filter accordingly.
+$hamburger-hover-use-filter   : false !default;
+$hamburger-hover-filter       : opacity(50%) !default;
+$hamburger-active-hover-filter: $hamburger-hover-filter !default;
+
+// Types (Remove or comment out what you don’t need)
+// ==================================================
+$hamburger-types: (
+  3dx,
+  3dx-r,
+  3dy,
+  3dy-r,
+  3dxy,
+  3dxy-r,
+  arrow,
+  arrow-r,
+  arrowalt,
+  arrowalt-r,
+  arrowturn,
+  arrowturn-r,
+  boring,
+  collapse,
+  collapse-r,
+  elastic,
+  elastic-r,
+  emphatic,
+  emphatic-r,
+  minus,
+  slider,
+  slider-r,
+  spin,
+  spin-r,
+  spring,
+  spring-r,
+  stand,
+  stand-r,
+  squeeze,
+  vortex,
+  vortex-r
+) !default;

--- a/_sass/hamburgers/hamburgers.scss
+++ b/_sass/hamburgers/hamburgers.scss
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+@charset 'UTF-8';
 /*!
  * Hamburgers
  * @description Tasty CSS-animated hamburgers
@@ -9,45 +9,45 @@
 
 // Hamburger variables
 // ==================================================
-@import "vars";
+@import 'vars';
 
 // Base Hamburger (We need this)
 // ==================================================
-@import "base";
+@import 'base';
 
 // Hamburger types
 // ==================================================
-@import "types/3dx";
-@import "types/3dx-r";
-@import "types/3dy";
-@import "types/3dy-r";
-@import "types/3dxy";
-@import "types/3dxy-r";
-@import "types/arrow";
-@import "types/arrow-r";
-@import "types/arrowalt";
-@import "types/arrowalt-r";
-@import "types/arrowturn";
-@import "types/arrowturn-r";
-@import "types/boring";
-@import "types/collapse";
-@import "types/collapse-r";
-@import "types/elastic";
-@import "types/elastic-r";
-@import "types/emphatic";
-@import "types/emphatic-r";
-@import "types/minus";
-@import "types/slider";
-@import "types/slider-r";
-@import "types/spin";
-@import "types/spin-r";
-@import "types/spring";
-@import "types/spring-r";
-@import "types/stand";
-@import "types/stand-r";
-@import "types/squeeze";
-@import "types/vortex";
-@import "types/vortex-r";
+@import 'types/3dx';
+@import 'types/3dx-r';
+@import 'types/3dy';
+@import 'types/3dy-r';
+@import 'types/3dxy';
+@import 'types/3dxy-r';
+@import 'types/arrow';
+@import 'types/arrow-r';
+@import 'types/arrowalt';
+@import 'types/arrowalt-r';
+@import 'types/arrowturn';
+@import 'types/arrowturn-r';
+@import 'types/boring';
+@import 'types/collapse';
+@import 'types/collapse-r';
+@import 'types/elastic';
+@import 'types/elastic-r';
+@import 'types/emphatic';
+@import 'types/emphatic-r';
+@import 'types/minus';
+@import 'types/slider';
+@import 'types/slider-r';
+@import 'types/spin';
+@import 'types/spin-r';
+@import 'types/spring';
+@import 'types/spring-r';
+@import 'types/stand';
+@import 'types/stand-r';
+@import 'types/squeeze';
+@import 'types/vortex';
+@import 'types/vortex-r';
 
 // ==================================================
 // Cooking up additional types:

--- a/_sass/hamburgers/hamburgers.scss
+++ b/_sass/hamburgers/hamburgers.scss
@@ -7,61 +7,9 @@
  * @link https://github.com/jonsuh/hamburgers
  */
 
-// Settings
+// Hamburger variables
 // ==================================================
-$hamburger-padding-x           : 15px !default;
-$hamburger-padding-y           : 15px !default;
-$hamburger-layer-width         : 40px !default;
-$hamburger-layer-height        : 4px !default;
-$hamburger-layer-spacing       : 6px !default;
-$hamburger-layer-color         : #000 !default;
-$hamburger-layer-border-radius : 4px !default;
-$hamburger-hover-opacity       : 0.7 !default;
-$hamburger-active-layer-color  : $hamburger-layer-color !default;
-$hamburger-active-hover-opacity: $hamburger-hover-opacity !default;
-
-// To use CSS filters as the hover effect instead of opacity,
-// set $hamburger-hover-use-filter as true and
-// change the value of $hamburger-hover-filter accordingly.
-$hamburger-hover-use-filter   : false !default;
-$hamburger-hover-filter       : opacity(50%) !default;
-$hamburger-active-hover-filter: $hamburger-hover-filter !default;
-
-// Types (Remove or comment out what you don’t need)
-// ==================================================
-$hamburger-types: (
-  3dx,
-  3dx-r,
-  3dy,
-  3dy-r,
-  3dxy,
-  3dxy-r,
-  arrow,
-  arrow-r,
-  arrowalt,
-  arrowalt-r,
-  arrowturn,
-  arrowturn-r,
-  boring,
-  collapse,
-  collapse-r,
-  elastic,
-  elastic-r,
-  emphatic,
-  emphatic-r,
-  minus,
-  slider,
-  slider-r,
-  spin,
-  spin-r,
-  spring,
-  spring-r,
-  stand,
-  stand-r,
-  squeeze,
-  vortex,
-  vortex-r
-) !default;
+@import "vars";
 
 // Base Hamburger (We need this)
 // ==================================================


### PR DESCRIPTION
Hi there! You have a very usefull project and I'm glad to use it!

Today I was trying to calculate the space your hamburger occupy using the project variables, but I stuck on the file importation part.

Instead of import the whole package, I'm importing only the base and the single animation file I want to use.

Since I also need to use the variables on the project, I need to import them too. The problem is that they're inside a file that import the whole project (including the animations that I don't want to load). Since I just want to import the vars, I decide to make this pull request. I think that it makes the code more flexible and improve the separation of concerns.