### PR TITLE
inherit for before and after instead of hamburger-active-layer-color;

### DIFF
--- a/_sass/hamburgers/_base.scss
+++ b/_sass/hamburgers/_base.scss
@@ -37,10 +37,12 @@
       }
     }
 
-    .hamburger-inner,
+    .hamburger-inner{
+      background-color: $hamburger-active-layer-color;
+    }
     .hamburger-inner::before,
     .hamburger-inner::after {
-      background-color: $hamburger-active-layer-color;
+			background-color: inherit;
     }
   }
 }
@@ -62,7 +64,7 @@
   &::after {
     width: $hamburger-layer-width;
     height: $hamburger-layer-height;
-    background-color: $hamburger-layer-color;
+    background-color: inherit;
     border-radius: $hamburger-layer-border-radius;
     position: absolute;
     transition-property: transform;


### PR DESCRIPTION
Since the ::before and ::after css pseudo elements are not accessible from Javascript, the color of the two bars at the bottom and top cannot be changed at runtime. By using "inherit" they will take over the color of middle bar thus the color can be changed dinamically.