### PR TITLE
fix: Deprecated / for division #104

### DIFF
--- a/_sass/hamburgers/_base.scss
+++ b/_sass/hamburgers/_base.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Hamburger
 // ==================================================
 .hamburger {
@@ -55,7 +57,7 @@
 .hamburger-inner {
   display: block;
   top: 50%;
-  margin-top: $hamburger-layer-height / -2;
+  margin-top: math.div($hamburger-layer-height, -2);
 
   &,
   &::before,

--- a/_sass/hamburgers/types/_elastic-r.scss
+++ b/_sass/hamburgers/types/_elastic-r.scss
@@ -1,10 +1,12 @@
+@use "sass:math";
+
 @if index($hamburger-types, elastic-r) {
   /*
    * Elastic Reverse
    */
   .hamburger--elastic-r {
     .hamburger-inner {
-      top: $hamburger-layer-height / 2;
+      top: math.div($hamburger-layer-height, 2);
       transition-duration: 0.275s;
       transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 

--- a/_sass/hamburgers/types/_elastic.scss
+++ b/_sass/hamburgers/types/_elastic.scss
@@ -1,10 +1,12 @@
+@use "sass:math";
+
 @if index($hamburger-types, elastic) {
   /*
    * Elastic
    */
   .hamburger--elastic {
     .hamburger-inner {
-      top: $hamburger-layer-height / 2;
+      top: math.div($hamburger-layer-height, 2);
       transition-duration: 0.275s;
       transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 

--- a/_sass/hamburgers/types/_slider-r.scss
+++ b/_sass/hamburgers/types/_slider-r.scss
@@ -1,10 +1,12 @@
+@use "sass:math";
+
 @if index($hamburger-types, slider-r) {
   /*
    * Slider Reverse
    */
   .hamburger--slider-r {
     .hamburger-inner {
-      top: $hamburger-layer-height / 2;
+      top: math.div($hamburger-layer-height, 2);
 
       &::before {
         top: $hamburger-layer-height + $hamburger-layer-spacing;
@@ -25,7 +27,7 @@
         transform: translate3d(0, $y-offset, 0) rotate(-45deg);
 
         &::before {
-          transform: rotate(45deg) translate3d($hamburger-layer-width / 7, $hamburger-layer-spacing * -1, 0);
+          transform: rotate(45deg) translate3d(math.div($hamburger-layer-width, 7), $hamburger-layer-spacing * -1, 0);
           opacity: 0;
         }
 

--- a/_sass/hamburgers/types/_slider.scss
+++ b/_sass/hamburgers/types/_slider.scss
@@ -1,10 +1,12 @@
+@use "sass:math";
+
 @if index($hamburger-types, slider) {
   /*
    * Slider
    */
   .hamburger--slider {
     .hamburger-inner {
-      top: $hamburger-layer-height / 2;
+      top: math.div($hamburger-layer-height, 2);
 
       &::before {
         top: $hamburger-layer-height + $hamburger-layer-spacing;
@@ -25,7 +27,7 @@
         transform: translate3d(0, $y-offset, 0) rotate(45deg);
 
         &::before {
-          transform: rotate(-45deg) translate3d($hamburger-layer-width / -7, $hamburger-layer-spacing * -1, 0);
+          transform: rotate(-45deg) translate3d(math.div($hamburger-layer-width, -7), $hamburger-layer-spacing * -1, 0);
           opacity: 0;
         }
 

--- a/_sass/hamburgers/types/_spring.scss
+++ b/_sass/hamburgers/types/_spring.scss
@@ -1,10 +1,12 @@
+@use "sass:math";
+
 @if index($hamburger-types, spring) {
   /*
    * Spring
    */
   .hamburger--spring {
     .hamburger-inner {
-      top: $hamburger-layer-height / 2;
+      top: math.div($hamburger-layer-height, 2);
       transition: background-color 0s 0.13s linear;
 
       &::before {


### PR DESCRIPTION
This fixes the deprecated warning for slash-div.
I used the Sass migrator to make the changes.